### PR TITLE
[fix] package.json is missing correct script, breaking package imports

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@zoralabs/media-metadata-schemas",
   "version": "0.1.2",
-  "main": "index.js",
+  "main": "dist/src/index.js",
   "typings": "dist/src/index.d.ts",
   "files": [
     "dist"


### PR DESCRIPTION
Package.json points to "index.js" when the correct file is "dist/src/index.js" mirroring the typescript types.